### PR TITLE
Wi-Fi設定の不備を修正

### DIFF
--- a/notebooks/99_tool.ipynb
+++ b/notebooks/99_tool.ipynb
@@ -17,18 +17,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "SSID = \"test_ssid\" # 接続するSSID(各環境に書き直す)\n",
-    "PASS = \"test_password\" # パスワード(各環境に書き直す)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9af80aad-44e3-4815-bad0-750fa00f2131",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!echo \"jetson\" | sudo -S nmcli connection add type wifi ifname wlan0 con-name \"jetracer-wpa2\" ssid $SSID wifi-sec.key-mgmt wpa-psk wifi-sec.psk $PASS"
+    "%%bash\n",
+    "export SSID=\"test_ssid\" # 接続するSSID(各環境に書き直す)\n",
+    "export PASS=\"test_password\" # パスワード(各環境に書き直す)\n",
+    "\n",
+    "export WIFI_DEVICE\n",
+    "WIFI_DEVICE=$(nmcli device | awk 'NR > 1 && $2 == \"wifi\" { print $1 }')\n",
+    "[ -z \"$WIFI_DEVICE\" ] && echo \"ERROR: Wi-Fi デバイスが見つかりません\" || true\n",
+    "\n",
+    "echo \"jetson\" | sudo -S nmcli connection add type wifi ifname \"$WIFI_DEVICE\" \\\n",
+    "    con-name \"jetracer-wpa2\" ssid \"$SSID\" wifi-sec.key-mgmt wpa-psk \\\n",
+    "    wifi-sec.psk \"$PASS\""
    ]
   },
   {


### PR DESCRIPTION
- Wi-Fi デバイス ID を `wlan0` 固定でなくクエリー取得するように修正
- 空白を含むパスワードに対応